### PR TITLE
Check record size before allocating

### DIFF
--- a/internal/proxy_router/sniffsni.go
+++ b/internal/proxy_router/sniffsni.go
@@ -66,6 +66,10 @@ func (s *SniSniffer) SniffSNI(conn net.Conn) (sni string, allData []byte, err er
 			_ = conn.SetReadDeadline(time.Now().Add(s.Timeout))
 		}
 
+		if len(allData)+recordLen > s.MaxReadSize {
+			return "", allData, fmt.Errorf("too much data without completing ClientHello, possible attack")
+		}
+
 		payload := make([]byte, recordLen)
 		if _, err := io.ReadFull(conn, payload); err != nil {
 			return "", allData, fmt.Errorf("failed reading record payload: %v", err)


### PR DESCRIPTION
## Summary
- avoid allocating huge slices in `SniffSNI`

## Testing
- `go test ./...`
