### PR TITLE
Add OriginScheme to backend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ configs:
           # a client cert). This is just an example path.
           RootCAFile: ca.crt
 
+          # OriginScheme indicates whether to connect to the origin via HTTP or HTTPS.
+          OriginScheme: http
+
           # OriginServer / OriginPort describe where to forward traffic after TLS termination.
           # For example, maybe your app is running on localhost:8080 inside the container.
           OriginServer: 127.0.0.1
@@ -169,6 +172,7 @@ configs:
           # They can be omitted or left blank in YAML if you wish.
 
           # The origin is presumably a TLS-enabled service on 192.168.0.10:443.
+          OriginScheme: https
           OriginServer: 192.168.0.10
           OriginPort: "443"
 
@@ -213,12 +217,14 @@ Backends:
     TLSCertFile: example.com.crt
     TLSKeyFile:  example.com.key
     RootCAFile:  ca.crt
+    OriginScheme: http
     OriginServer: 127.0.0.1
     OriginPort: "8080"
 
   - hostname: foo.bar
     MTLSEnabled: false   # no mTLS for foo.bar
     TerminateTLS: false  # pass-through raw TCP
+    OriginScheme: https
     OriginServer: 192.168.0.10
     OriginPort: "443"
 ```
@@ -241,8 +247,8 @@ suhaibserver <config-file>
   - `Hostname` - matches the SNI requested by the client.
   - `TerminateTLS` (true/false).
   - `MTLSEnabled` (true/false) and optional `MTLSPolicy` for partial or conditional mTLS.  
-  - `TLSCertFile`, `TLSKeyFile`, `RootCAFile` (paths to certificates/keys).  
-  - `OriginServer` and `OriginPort` (where traffic is forwarded).
+  - `TLSCertFile`, `TLSKeyFile`, `RootCAFile` (paths to certificates/keys).
+  - `OriginScheme` (`http` or `https`), plus `OriginServer` and `OriginPort` (where traffic is forwarded).
 
 ---
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,6 +42,9 @@ Backends:
     # a client cert). This is just an example path.
     RootCAFile: ca.crt
 
+    # OriginScheme indicates whether to connect to the origin via HTTP or HTTPS.
+    OriginScheme: http
+
     # OriginServer / OriginPort describe where to forward traffic after TLS termination.
     # For example, maybe your app is running on localhost:8080 inside the container.
     OriginServer: 127.0.0.1
@@ -58,5 +61,6 @@ Backends:
     # They can be omitted or left blank in YAML if you wish.
 
     # The origin is presumably a TLS-enabled service on 192.168.0.10:443.
+    OriginScheme: https
     OriginServer: 192.168.0.10
     OriginPort: "443"

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -101,6 +101,9 @@ type BackendConfig struct {
 	TLSKeyFile  string `yaml:"TlsKeyFile"   json:"TlsKeyFile"`
 	RootCAFile  string `yaml:"RootCAFile"   json:"RootCAFile"`
 
+	// OriginScheme specifies the protocol (http or https) used to reach the origin.
+	OriginScheme string `yaml:"OriginScheme" json:"OriginScheme"`
+
 	OriginServer string `yaml:"OriginServer" json:"OriginServer"`
 	OriginPort   string `yaml:"OriginPort"   json:"OriginPort"`
 }


### PR DESCRIPTION
## Summary
- add `OriginScheme` to BackendConfig and Backend structs
- update reverse proxy builder to use scheme
- document `OriginScheme` in README and config example
- adjust tests for new field

## Testing
- `go test ./...`
